### PR TITLE
Adds Debian Package Build & ARMv7 Support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,15 +18,15 @@ builds:
     gomips:
       - softfloat
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
-  files:
-    - example.yaml
-    - systemd/*
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    files:
+      - example.yaml
+      - systemd/*
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -35,8 +35,8 @@ changelog:
   sort: asc
   filters:
     exclude:
-    - '^docs:'
-    - '^test:'
+      - '^docs:'
+      - '^test:'
 release:
   github:
     owner: dschanoeh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,8 @@
 before:
   hooks:
 builds:
-  - env:
+  - id: "linux"
+    env:
       - CGO_ENABLED=0
     goarch:
       - amd64
@@ -9,14 +10,21 @@ builds:
       - arm64
       - mipsle
     goos:
-      - darwin
       - linux
-      - windows
     goarm:
       - 6
       - 7
     gomips:
       - softfloat
+  - id: "non-linux"
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm64
+    goos:
+      - darwin
+      - windows
 archives:
   - replacements:
       darwin: Darwin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,27 @@ archives:
     files:
       - example.yaml
       - systemd/*
+nfpms:
+  - builds:
+      - "linux"
+    replacements:
+      amd64: x86_64
+      linux: Linux
+    homepage: https://github.com/dschanoeh/hover-ddns
+    maintainer: Jan-Niklas Meier <jan@jansblog.org>
+    description: A Dynamic DNS client for the unofficial Hover API.
+    license: Apache 2.0
+    formats:
+      - deb
+    contents:
+      - src: example.yaml
+        dst: /etc/hover-ddns.yaml
+        type: config
+      - src: systemd/hover-ddns.service
+        dst: /etc/systemd/system/hover-ddns.service
+        type: config
+    scripts:
+      postinstall: scripts/postinstall.sh
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,9 @@ builds:
       - darwin
       - linux
       - windows
+    goarm:
+      - 6
+      - 7
     gomips:
       - softfloat
 archives:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ the following commands.
 
 This is an example setup on Linux using the provided systemd service and timer.
 
-[Download the latest release](https://github.com/dschanoeh/hover-ddns/releasesa)
+[Download the latest release](https://github.com/dschanoeh/hover-ddns/releases)
 and run the following commands.
 
     $ tar xvf [downloaded_archive.tar.gz]

--- a/README.md
+++ b/README.md
@@ -32,9 +32,25 @@ Create a config file with your credentials and domain info (see the provided exa
 
 ## Installation
 
+### Debian-based Linux Distributions
+
+Download the deb corresponding to your architecture from
+[the releases page](https://github.com/dschanoeh/hover-ddns/releases) and run
+the following commands.
+
+    $ sudo dpkg -i [downloaded_deb.deb]
+    
+    [Customize /etc/hover-ddns.yaml with your domain information and other preferences]
+
+    $ sudo systemctl start hover-ddns.service
+
+
+### Manually
+
 This is an example setup on Linux using the provided systemd service and timer.
 
-Download the latest release from https://github.com/dschanoeh/hover-ddns/releases.
+[Download the latest release](https://github.com/dschanoeh/hover-ddns/releasesa)
+and run the following commands.
 
     $ tar xvf [downloaded_archive.tar.gz]
     $ sudo mv hover-ddns /usr/local/bin

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+systemctl daemon-reload
+systemctl enable hover-ddns.service


### PR DESCRIPTION
Like the title says, this PR contains some changes to the goreleaser config that enables the following:
* ARMv7 support. This is useful if you want to run this on last generation Raspberry Pis that are running recent revisions of Rasbian.
* Adds NFPM configuration. This builds deb packages compatible with any Debian-based distro. This makes a little bit easier to install this software.
  * Adds scripts/postinstall.sh. This is included in the deb package and tells systemd to reload its units upon install.

The project readme was also updated to reflect these changes.